### PR TITLE
Better benchmarks

### DIFF
--- a/src/sincos.c
+++ b/src/sincos.c
@@ -39,16 +39,18 @@
 /* } */
 
 /* trying to store the result in a mutable floats struct */
-CAMLprim value caml_sincos_float(value f, value res) {
-  CAMLparam2 (f, res);
-
+CAMLprim value caml_sincos_float(double f, value res) {
   double x;
   double y;
 
-  sincos(Double_val(f), &x, &y);
+  sincos(f, &x, &y);
 
   Store_double_flat_field(res, 0, x);
   Store_double_flat_field(res, 1, y);
 
-  CAMLreturn (Val_unit);
+  return (Val_unit);
+}
+
+CAMLprim value caml_sincos_float_boxed(value f, value res) {
+  return caml_sincos_float(Double_val(f), res);
 }

--- a/src/sincos.ml
+++ b/src/sincos.ml
@@ -5,4 +5,5 @@
 type sincos_res = { mutable sin: float ;
                     mutable cos: float }
 
-external sincos: float -> sincos_res -> unit = "caml_sincos_float"
+external sincos : (float [@unboxed]) -> sincos_res -> unit = "caml_sincos_float_boxed" "caml_sincos_float"
+  [@@noalloc]

--- a/src/test_sin_cos.ml
+++ b/src/test_sin_cos.ml
@@ -1,17 +1,21 @@
-
-module A = Array
+module A = Float.Array
 
 let pi = 4.0 *. atan 1.0
 
 let main () =
-  let n = 30_000_000 in
-  let alphas = A.init n (fun i -> (float i) *. pi /. (float n)) in
+  let datalen = 1000 in
+  let alphas = A.init datalen (fun i -> float i *. pi /. float datalen) in
+  let n = 30_000 in
   let t0 = Unix.gettimeofday () in
-  for i = 0 to n - 1 do
-    let a = A.unsafe_get alphas i in
-    let _ = (sin a, cos a) in ()
+  let res = Sincos.{ sin = 0.0; cos = 0.0 } in
+  for _ = 1 to n do
+    for i = 0 to datalen - 1 do
+      let x = A.unsafe_get alphas i in
+      res.sin <- sin x;
+      res.cos <- cos x;
+    done;
   done;
   let t1 = Unix.gettimeofday () in
-  Printf.printf "sin_cos: %f\n" (t1 -. t0)
+  Printf.printf "sincos_: %f\n" (t1 -. t0)
 
 let () = main ()

--- a/src/test_sincos.ml
+++ b/src/test_sincos.ml
@@ -1,16 +1,18 @@
-
-module A = Array
+module A = Float.Array
 
 let pi = 4.0 *. atan 1.0
 
 let main () =
-  let n = 30_000_000 in
-  let alphas = A.init n (fun i -> (float i) *. pi /. (float n)) in
+  let datalen = 1000 in
+  let alphas = A.init datalen (fun i -> float i *. pi /. float datalen) in
+  let n = 30_000 in
   let t0 = Unix.gettimeofday () in
-  let res = Sincos.{ sin = 0.0; cos = 0.0 } in  
-  for i = 0 to n - 1 do
-    let a = A.unsafe_get alphas i in
-    Sincos.sincos a res
+  let res = Sincos.{ sin = 0.0; cos = 0.0 } in
+  for _ = 1 to n do
+    for i = 0 to datalen - 1 do
+      let x = A.unsafe_get alphas i in
+      Sincos.sincos x res;
+    done;
   done;
   let t1 = Unix.gettimeofday () in
   Printf.printf "sincos_: %f\n" (t1 -. t0)

--- a/test.sh
+++ b/test.sh
@@ -4,10 +4,6 @@ dune build @all
 
 _build/default/src/test_no_regr.exe
 
-for i in `seq 1 5`; do
-    _build/default/src/test_sin_cos.exe
-done
-
-for i in `seq 1 5`; do
-    _build/default/src/test_sincos.exe
-done
+hyperfine \
+  _build/default/src/test_sin_cos.exe \
+  _build/default/src/test_sincos.exe


### PR DESCRIPTION
(see each commit separately)

Even with these improved benchmarks, the conclusion is that on my machine there is no measurable performance difference between calling `sincos`, on one hand, or `sin` and `cos` on the other:

```
$ sh test.sh
Benchmark 1: _build/default/src/test_sin_cos.exe
  Time (mean ± σ):      1.063 s ±  0.029 s    [User: 1.059 s, System: 0.001 s]
  Range (min … max):    1.040 s …  1.138 s    10 runs
 
Benchmark 2: _build/default/src/test_sincos.exe
  Time (mean ± σ):      1.053 s ±  0.022 s    [User: 1.048 s, System: 0.001 s]
  Range (min … max):    1.030 s …  1.092 s    10 runs
 
Summary
  '_build/default/src/test_sincos.exe' ran
    1.01 ± 0.03 times faster than '_build/default/src/test_sin_cos.exe'
```